### PR TITLE
.editorconfig ファイルへ *.csproj ファイル設定の追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,6 @@ insert_final_newline = false
 indent_size = 4
 indent_style = space
 trim_trailing_whitespace = true
+
+[*.csproj]
+indent_size = 2


### PR DESCRIPTION
現在の .editorconfig は 4 スペース インデントが設定されていますが、.csproj ファイルは 2 スペース インデントです。
現在の .editorconfig では .csproj ファイルを触るたびにインデントを変えてしまいます。

.editorconfig に .csproj ファイルの 2 スペース インデントを設定しました。